### PR TITLE
Added per page trademark attribution.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -77,11 +77,7 @@
     <div class="wrapper">
         <div>
             <div class="copyright">&copy; Copyright {{ 'now' | date: "%Y" }} SYCLOPS</div>
-            <div class="attribution">
-                Codasip and the Codasip logo are registered trademarks or trademarks of Codasip Group.
-                Codeplay and the Codeplay logo are registered trademarks of Codeplay Software Ltd.
-                CERN and the CERN logo are trademarks and brand of EUROPEAN ORGANIZATION FOR NUCLEAR RESEARCH.
-            </div>
+            <div class="attribution">{{page.trademarks | join: '. '}}</div>
             <div class="policies">
                 <a href="{{'cookies' | absolute_url}}">Cookie Policy</a>
                 <a href="{{'privacy' | absolute_url}}">Privacy Policy</a>

--- a/about.html
+++ b/about.html
@@ -1,5 +1,15 @@
 ---
 layout: page
+trademarks:
+  - Nvidia is a registered trademark of NVIDIA Corporation
+  - AMD is a registered trademark of Advanced Micro Devices, Inc
+  - SYCL is a trademark of the Khronos Group
+  - Khronos is a trademark of the Khronos Group
+  - The "RISC-V" trade name is a registered trademark of RISC-V International
+  - CUDA is a registered trademark of NVIDIA Corporation
+  - Codasip and the Codasip logo are registered trademarks or trademarks of Codasip Group
+  - Codeplay and the Codeplay logo are registered trademarks of Codeplay Software Ltd
+  - CERN and the CERN logo are trademarks and brand of EUROPEAN ORGANIZATION FOR NUCLEAR RESEARCH
 ---
 
 <!-- Section: About -->

--- a/consortium.html
+++ b/consortium.html
@@ -1,5 +1,9 @@
 ---
 layout: page
+trademarks:
+  - Codasip and the Codasip logo are registered trademarks or trademarks of Codasip Group
+  - Codeplay and the Codeplay logo are registered trademarks of Codeplay Software Ltd
+  - CERN and the CERN logo are trademarks and brand of EUROPEAN ORGANIZATION FOR NUCLEAR RESEARCH
 ---
 
 <!-- Section: Consortium -->

--- a/index.html
+++ b/index.html
@@ -1,6 +1,10 @@
 ---
 layout: page
 header: expanded
+trademarks:
+  - SYCL is a trademark of the Khronos Group
+  - Codasip and the Codasip logo are registered trademarks or trademarks of Codasip Group
+  - Codeplay and the Codeplay logo are registered trademarks of Codeplay Software Ltd
 ---
 
 <!-- Section: Tabs -->

--- a/privacy.html
+++ b/privacy.html
@@ -1,5 +1,7 @@
 ---
 layout: page
+trademarks:
+  - Codeplay and the Codeplay logo are registered trademarks of Codeplay Software Ltd
 ---
 
 <!-- Section: Privacy -->


### PR DESCRIPTION
Each page can now define which trademarks they have referenced using the Jekyll front-matter. These will be combined and added to the trademark attribution footer on the main layout.