### PR TITLE
Combination of Consortium Members

### DIFF
--- a/_configs/_config.yml
+++ b/_configs/_config.yml
@@ -20,6 +20,33 @@ exclude:
 twitter: https://twitter.com/syclopseu
 youtube: https://www.youtube.com/@syclopseu
 
+# List of consortium members (in alphabetical order)
+consortium_members:
+  - name: "Accelom"
+    url: "https://accelom.com/"
+    logo: "static/images/partners/accelom.png"
+  - name: "CERN"
+    url: "https://www.cern"
+    logo: "static/images/partners/cern.png"
+  - name: "Codasip"
+    url: "https://www.codasip.com"
+    logo: "static/images/partners/codasip.png"
+  - name: "Codeplay"
+    url: "https://www.codeplay.com"
+    logo: "static/images/partners/codeplay.png"
+  - name: "Eurecom"
+    url: "https://www.eurecom.fr/en"
+    logo: "static/images/partners/eurecom.png"
+  - name: "Heidelberg"
+    url: "https://www.uni-heidelberg.de/en"
+    logo: "static/images/partners/heidelberg.png"
+  - name: "HIRO Microdatacenters"
+    url: "https://hiro-microdatacenters.nl"
+    logo: "static/images/partners/hiro.png"
+  - name: "INESC-ID"
+    url: "https://www.inesc-id.pt"
+    logo: "static/images/partners/inescid.png"
+
 includes_dir: "/"
 
 sass:

--- a/_includes/consortium/community.html
+++ b/_includes/consortium/community.html
@@ -1,8 +1,0 @@
-<a class="eurecom" href="https://www.eurecom.fr/en" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/eurecom.png' | absolute_url}}" alt="Eurecom Logo" /></a>
-<a class="inescid" href="https://www.inesc-id.pt/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/inescid.png' | absolute_url}}" alt="INESC-ID Logo" /></a>
-<a class="heidelberg" href="https://www.uni-heidelberg.de/en" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/heidelberg.png' | absolute_url}}" alt="Heidelberg Logo" /></a>
-<a class="cern" href="https://home.web.cern.ch/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/cern.png' | absolute_url}}" alt="CERN Logo" /></a>

--- a/_includes/consortium/members.html
+++ b/_includes/consortium/members.html
@@ -1,23 +1,4 @@
-<a class="accelom" href="https://accelom.com/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/accelom.png' | absolute_url}}" alt="Accelom Logo" /></a>
-
-<a class="cern" href="https://home.web.cern.ch/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/cern.png' | absolute_url}}" alt="CERN Logo" /></a>
-
-<a class="codasip" href="https://codasip.com/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/codasip.png' | absolute_url}}" alt="Codasip Logo" /></a>
-
-<a class="codeplay" href="https://codeplay.com" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/codeplay.png' | absolute_url}}" alt="Codeplay Logo" /></a>
-
-<a class="eurecom" href="https://www.eurecom.fr/en" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/eurecom.png' | absolute_url}}" alt="Eurecom Logo" /></a>
-
-<a class="heidelberg" href="https://www.uni-heidelberg.de/en" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/heidelberg.png' | absolute_url}}" alt="Heidelberg Logo" /></a>
-
-<a class="hiro" href="https://hiro-microdatacenters.nl/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/hiro.png' | absolute_url}}" alt="HIRO Microdatacenters Logo" /></a>
-
-<a class="inescid" href="https://www.inesc-id.pt/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/inescid.png' | absolute_url}}" alt="INESC-ID Logo" /></a>
+{% for member in site.consortium_members %}
+<a class="{{member.name | slugify}}" href="{{member.url}}" target="_blank" rel="noopener">
+  <img src="{{member.logo | absolute_url}}" alt="{{member.name}} Logo" /></a>
+{% endfor %}

--- a/_includes/consortium/members.html
+++ b/_includes/consortium/members.html
@@ -1,0 +1,23 @@
+<a class="accelom" href="https://accelom.com/" target="_blank" rel="noopener">
+  <img src="{{'static/images/partners/accelom.png' | absolute_url}}" alt="Accelom Logo" /></a>
+
+<a class="cern" href="https://home.web.cern.ch/" target="_blank" rel="noopener">
+  <img src="{{'static/images/partners/cern.png' | absolute_url}}" alt="CERN Logo" /></a>
+
+<a class="codasip" href="https://codasip.com/" target="_blank" rel="noopener">
+  <img src="{{'static/images/partners/codasip.png' | absolute_url}}" alt="Codasip Logo" /></a>
+
+<a class="codeplay" href="https://codeplay.com" target="_blank" rel="noopener">
+  <img src="{{'static/images/partners/codeplay.png' | absolute_url}}" alt="Codeplay Logo" /></a>
+
+<a class="eurecom" href="https://www.eurecom.fr/en" target="_blank" rel="noopener">
+  <img src="{{'static/images/partners/eurecom.png' | absolute_url}}" alt="Eurecom Logo" /></a>
+
+<a class="heidelberg" href="https://www.uni-heidelberg.de/en" target="_blank" rel="noopener">
+  <img src="{{'static/images/partners/heidelberg.png' | absolute_url}}" alt="Heidelberg Logo" /></a>
+
+<a class="hiro" href="https://hiro-microdatacenters.nl/" target="_blank" rel="noopener">
+  <img src="{{'static/images/partners/hiro.png' | absolute_url}}" alt="HIRO Microdatacenters Logo" /></a>
+
+<a class="inescid" href="https://www.inesc-id.pt/" target="_blank" rel="noopener">
+  <img src="{{'static/images/partners/inescid.png' | absolute_url}}" alt="INESC-ID Logo" /></a>

--- a/_includes/consortium/partners.html
+++ b/_includes/consortium/partners.html
@@ -1,8 +1,0 @@
-<a class="codasip" href="https://codasip.com/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/codasip.png' | absolute_url}}" alt="Codasip Logo" /></a>
-<a class="hiro" href="https://hiro-microdatacenters.nl/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/hiro.png' | absolute_url}}" alt="HIRO Microdatacenters Logo" /></a>
-<a class="codeplay" href="https://codeplay.com" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/codeplay.png' | absolute_url}}" alt="Codeplay Logo" /></a>
-<a class="accelom" href="https://accelom.com/" target="_blank" rel="noopener">
-  <img src="{{'static/images/partners/accelom.png' | absolute_url}}" alt="Accelom Logo" /></a>

--- a/about.html
+++ b/about.html
@@ -37,28 +37,13 @@ layout: page
                     AI systems.</p>
             </div>
             <div>
-                <h2>Visit Partners</h2>
+                <h2>Consortium Members</h2>
                 <ul class="links">
+                    {% for member in site.consortium_members %}
                     <li>
-                        <a href="https://codasip.com/"
-                           target="_blank"
-                           rel="noopener">Codasip</a>
+                        <a href="{{member.url}}" target="_blank" rel="noopener">{{member.name}}</a>
                     </li>
-                    <li>
-                        <a href="https://hiro-microdatacenters.nl/"
-                           target="_blank"
-                           rel="noopener">HIRO Microdatacenters</a>
-                    </li>
-                    <li>
-                        <a href="https://codeplay.com"
-                           target="_blank"
-                           rel="noopener">Codeplay&reg;</a>
-                    </li>
-                    <li>
-                        <a href="https://accelom.com/"
-                           target="_blank"
-                           rel="noopener">Accelom</a>
-                    </li>
+                    {% endfor %}
                 </ul>
 
                 <h2>Other Links</h2>

--- a/consortium.html
+++ b/consortium.html
@@ -7,24 +7,15 @@ layout: page
     <div class="wrapper">
         <h1><span class="material-icons">diversity_1</span>Consortium</h1>
 
-        <p>This project is supported by a number of partners and community members. We would like to thank everyone
+        <p>This project is supported by a number of project collaborators. We would like to thank everyone
             involved for making this project a success.</p>
 
         <br />
         <br />
 
-        <h2>Partners</h2>
-
         <!-- Consortium -->
         <div class="partners">
-            {%- include _includes/consortium/partners.html -%}
-        </div>
-
-        <h2>Community</h2>
-
-        <!-- Consortium -->
-        <div class="partners">
-            {%- include _includes/consortium/community.html -%}
+            {%- include _includes/consortium/members.html -%}
         </div>
     </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ header: expanded
     <div class="wrapper">
         <!-- Consortium -->
         <div class="partners">
-            {%- include _includes/consortium/partners.html -%}
+            {%- include _includes/consortium/members.html -%}
         </div>
     </div>
 </section>


### PR DESCRIPTION
This PR does the following:

- All consortium members are part of the same "group"
- Consortium members are now defined in an alphabetically ordered list in _config.yml
- All consortium members now show on consortium.html and home page
- All consortium members now appear in about.html site list