### PR TITLE
Replaced Google Analytics with Fathom Analytics.

### DIFF
--- a/_configs/_config_production.yml
+++ b/_configs/_config_production.yml
@@ -1,4 +1,4 @@
 url: https://www.syclops.org
 
-# Google Analytics Token
-ga: 'G-CZ9WF91EQN'
+# Fathom Analytics Token
+fa: 'QLYBRUST'

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -42,8 +42,6 @@
             crossorigin="anonymous"></script>
     <script src="{{'/static/js/jquery.cookiesaccepted.js' | absolute_url}}"
             type="text/javascript"></script>
-    <script src="{{'/static/js/index.js' | absolute_url}}"
-            type="text/javascript"></script>
 
     <!-- Fathom -->
     <script src="https://cdn.usefathom.com/script.js" data-site="{{ site.fa }}" defer></script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -45,6 +45,9 @@
     <script src="{{'/static/js/index.js' | absolute_url}}"
             type="text/javascript"></script>
 
+    <!-- Fathom -->
+    <script src="https://cdn.usefathom.com/script.js" data-site="{{ site.fa }}" defer></script>
+
     <!-- Content security policy -->
     <meta content="
                 default-src
@@ -62,21 +65,21 @@
                     'self'
                     https://code.jquery.com
                     https://www.googletagmanager.com
-                    https://www.google-analytics.com;
+                    https://cdn.usefathom.com/script.js;
                 connect-src
                     'self'
-                    https://*.google-analytics.com;
+                    https://cdn.usefathom.com;
                 img-src
                     'self'
                     https:
                     http:
                     data:
-                    https://*.google-analytics.com;
+                    https://cdn.usefathom.com;
                 frame-src
                     'self';"
           http-equiv="Content-Security-Policy"/>
 </head>
-<body data-ga="{{site.ga}}">
+<body>
 {%- if header == 'expanded' -%}
 {%- include _includes/headers/expanded.html -%}
 {%- else -%}

--- a/cookies.html
+++ b/cookies.html
@@ -49,57 +49,5 @@ layout: page
             </tr>
         </table>
 
-        <h3>Google Analytics</h3>
-
-        <p>We use Google Analytics to track how our website is used to help us improve our
-            services. Google Analytics will often set a tracking cookie on your system.</p>
-
-        <p><b>Please note </b> that we have enabled "anonymous" mode on Google Analytics. As a result,
-            we do not store any information that directly identifies you but we can still capture visitor
-            interactions. If you wish to disable these completely, please reject them using the button
-            above.</p>
-
-        <p><a href="https://policies.google.com/privacy" target="_blank">
-            View Google's Privacy Policy</a></p>
-
-        <table>
-            <thead>
-            <tr>
-                <th>Cookie Name</th>
-                <th>Whats It For?</th>
-                <th>Type</th>
-            </tr>
-            </thead>
-            <tr>
-                <td>_ga</td>
-                <td>Used to distinguish users.</td>
-                <td>
-                    <div class="tag">1st Party Cookie</div>
-                </td>
-            </tr>
-            <tr>
-                <td>_gid</td>
-                <td>Used to distinguish users.</td>
-                <td>
-                    <div class="tag">1st Party Cookie</div>
-                </td>
-            </tr>
-            <tr>
-                <td>_ga_&lt;container-id&gt;</td>
-                <td>Used to persist session state.</td>
-                <td>
-                    <div class="tag">1st Party Cookie</div>
-                </td>
-            </tr>
-            <tr>
-                <td>_gac_gb_&lt;container-id&gt;</td>
-                <td>Contains campaign related information. If you have linked your Google
-                    Analytics and Google Ads accounts, Google Ads website conversion tags will
-                    read this cookie unless you opt-out.</td>
-                <td>
-                    <div class="tag">1st Party Cookie</div>
-                </td>
-            </tr>
-        </table>
     </div>
 </section>

--- a/privacy.html
+++ b/privacy.html
@@ -65,7 +65,6 @@ layout: page
             <li>Formspree</li>
             <li>Microsoft Office 365</li>
             <li>JIRA</li>
-            <li>Google Analytics (limited information, if accepted)</li>
         </ul>
 
         <h2>Your data protection rights</h2>

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,3 +1,0 @@
-$(() => {
-    const cookies = $('#cookies-accept-dialog').CookiesAccepted();
-});

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,13 +1,3 @@
 $(() => {
     const cookies = $('#cookies-accept-dialog').CookiesAccepted();
-
-    if(cookies.isEnabled()) {
-        // Google Analytics
-        const gaToken = $('body').data('ga');
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', gaToken);
-        $.getScript('https://www.googletagmanager.com/gtag/js?id=' + gaToken);
-    }
 });


### PR DESCRIPTION
Replaces Google Analytics with Fathom analytics, which allows us to track without cookies of privacy concerns.